### PR TITLE
Improve behavior

### DIFF
--- a/src/AnalyzeCommand.php
+++ b/src/AnalyzeCommand.php
@@ -60,11 +60,17 @@ final class AnalyzeCommand extends Command
         }
 
         $io->title('Psssst, the amazing PrestaShop module parser!');
-        
-        foreach ($moduleData as $module => $hooks) {
-            $io->section("Detecting hooks in module $module");
-            $io->listing($hooks);
-        }  
+
+        foreach ($moduleData as $module) {
+            $io->section(
+                sprintf(
+                    'Detecting hooks in module %s:%s',
+                    $module['name'],
+                    $module['version']
+                )
+            );
+            $io->listing($module['hooks']);
+        }
 
         $io->success('Analysis done with success.');
     }

--- a/src/HookVisitor.php
+++ b/src/HookVisitor.php
@@ -5,7 +5,7 @@ namespace Psssst;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt;
 
 class HookVisitor extends NodeVisitorAbstract
 {
@@ -13,30 +13,49 @@ class HookVisitor extends NodeVisitorAbstract
 
     public static $module = null;
 
+    public static $version = null;
+
     public static function reset()
     {
         self::$hooks = [];
         self::$module = null;
+        self::$version = null;
     }
 
-    public function enterNode(Node $node) {
-        if ($node instanceof Node\Stmt\Class_
-            && (string)$node->extends === 'Module'
-        ) {
-            self::$module = $node->name->name;
-
-            return;
+    public function enterNode(Node $node)
+    {
+        if ($this->nodeHasProperty($node, 'name')) {
+            self::$module = $node->expr->value;
         }
 
-        if ($node instanceof ClassMethod) {
-            if (null === self::$module) {
-                return;
-            }
+        if ($this->nodeHasProperty($node, 'version')) {
+            self::$version = $node->expr->value;
+        }
 
+        if ($node instanceof Stmt\ClassMethod) {
             $methodName = $node->name->name;
             if (strpos($methodName, 'hook') !== false) {
                 self::$hooks[] = lcfirst(substr($methodName, 4));
             }
         }
+    }
+
+    /**
+     * Check if node is a property of a class
+     *
+     * @param Node   $node Node
+     * @param string $name Name of the property
+     *
+     * @return boolean
+     */
+    protected function nodeHasProperty($node, $name)
+    {
+        return $node instanceof Node\Expr\Assign &&
+            $node->var instanceof Node\Expr\PropertyFetch &&
+            $node->var->var instanceof Node\Expr\Variable &&
+            $node->var->var->name === 'this' &&
+            $node->var->name instanceof Node\Identifier &&
+            $node->var->name->name === $name &&
+            $node->expr instanceof Node\Scalar\String_;
     }
 }

--- a/src/ModuleParser.php
+++ b/src/ModuleParser.php
@@ -47,22 +47,29 @@ final class ModuleParser
         $finder = new Finder();
         $files = $finder->files()->name('*.php')->in($modulePath);
         $hooks = [];
-        
+
         foreach ($files as $file) {
             try {
                 $stmts = $this->phpParser->parse($file->getContents());
-                
+
                 $stmts = $this->phpTraverser->traverse($stmts);
 
-                if (!empty($this->hookVisitor::$hooks)) {
-                    $hooks[$this->hookVisitor::$module] = $this->hookVisitor::$hooks;
+                if (!empty($this->hookVisitor::$hooks) &&
+                    !empty($this->hookVisitor::$version) &&
+                    !empty($this->hookVisitor::$module)
+                ) {
+                    $hooks[] = [
+                        'name' => $this->hookVisitor::$module,
+                        'version' => $this->hookVisitor::$version,
+                        'hooks' => $this->hookVisitor::$hooks,
+                    ];
                 }
             } catch (Error $e) {
                 echo 'Parse Error: ', $e->getMessage();
             }
             $this->hookVisitor::reset();
         }
-        
+
         return $hooks;
     }
 }


### PR DESCRIPTION
Module must be identify by his `$this->name` instead of his class name and extension because some module extends paymentModule, ModuleGridEngine, etc.

Add version to change how data is displayed in json.

Example:
[
  {
    "version": "1.6.3",
    "name": "mercanet",
    "hooks": [
      "backOfficeHeader",
      "header",
      "payment",
      "displayAdminProductsExtra",
      "actionProductUpdate",
      "displayAdminOrder",
      "displayCustomerAccount",
      "paymentReturn"
    ]
  }
]