### PR TITLE
Parse author & tab and handle `l()` translation function

### DIFF
--- a/src/AnalyzeCommand.php
+++ b/src/AnalyzeCommand.php
@@ -65,9 +65,13 @@ final class AnalyzeCommand extends Command
                 )
             );
             $io->definitionList(
+                ['DisplayName' => $module['displayName']],
+                ['Author' => $module['author']],
                 ['Version' => $module['version']],
                 ['Min' => $module['versionCompliancyMin']],
                 ['Max' => $module['versionCompliancyMax']],
+                ['Description' => $module['description']],
+                ['Tab' => $module['tab']]
             );
 
             $io->text('Hooks:');

--- a/src/HookVisitor.php
+++ b/src/HookVisitor.php
@@ -99,7 +99,7 @@ class HookVisitor extends NodeVisitorAbstract
                 $node->expr instanceof Node\Scalar\String_ ||
                 $node->expr instanceof Node\Expr\Array_ ||
                 $node->expr instanceof Node\Expr\MethodCall &&
-                $node->expr->name->name === 'trans'
+                ($node->expr->name->name === 'trans' || $node->expr->name->name === 'l')
             );
     }
 
@@ -123,7 +123,10 @@ class HookVisitor extends NodeVisitorAbstract
 
     protected function getString($node)
     {
-        if ($node->expr instanceof Node\Expr\MethodCall && $node->expr->name->name === 'trans') {
+        if (
+            $node->expr instanceof Node\Expr\MethodCall
+            && ($node->expr->name->name === 'trans' || $node->expr->name->name === 'l')
+        ) {
             return $node->expr->args[0]->value->value;
         } else if ($node->expr instanceof Node\Scalar\String_) {
             return $node->expr->value;

--- a/src/HookVisitor.php
+++ b/src/HookVisitor.php
@@ -17,6 +17,10 @@ class HookVisitor extends NodeVisitorAbstract
 
     public static $version = null;
 
+    public static $author = null;
+
+    public static $tab = null;
+
     public static $description = null;
 
     public static $versionsCompliancyMin = null;
@@ -28,6 +32,9 @@ class HookVisitor extends NodeVisitorAbstract
         self::$hooks = [];
         self::$module = null;
         self::$version = null;
+        self::$author = null;
+        self::$tab = null;
+        self::$displayName = null;
         self::$versionsCompliancyMin = null;
         self::$versionsCompliancyMax = null;
         self::$description = null;
@@ -41,6 +48,14 @@ class HookVisitor extends NodeVisitorAbstract
 
         if ($this->nodeHasProperty($node, 'version')) {
             self::$version = $node->expr->value;
+        }
+
+        if ($this->nodeHasProperty($node, 'author')) {
+            self::$author = $node->expr->value;
+        }
+
+        if ($this->nodeHasProperty($node, 'tab')) {
+            self::$tab = $node->expr->value;
         }
 
         if ($this->nodeHasProperty($node, 'displayName')) {

--- a/src/ModuleParser.php
+++ b/src/ModuleParser.php
@@ -61,6 +61,8 @@ final class ModuleParser
                         'name' => $this->hookVisitor::$module,
                         'displayName' => $this->hookVisitor::$displayName,
                         'version' => $this->hookVisitor::$version,
+                        'author' => $this->hookVisitor::$author,
+                        'tab' => $this->hookVisitor::$tab,
                         'description' => $this->hookVisitor::$description,
                         'versionCompliancyMin' => $this->hookVisitor::$versionsCompliancyMin,
                         'versionCompliancyMax' => $this->hookVisitor::$versionsCompliancyMax,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to return the author & tab of a module being parsed along with the other info already returned. It Also get the string of the `l()` function the same way it does with the `trans()` function.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Try `./psssst /directory/of/a/module/` and check that the author and tab are returned.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
